### PR TITLE
[add]: Query info from node.

### DIFF
--- a/backend/api/queries.py
+++ b/backend/api/queries.py
@@ -1,6 +1,7 @@
 from .models import *
 from ariadne import QueryType
 from .store import queues, alerts
+from src.nodes.node_registry import NodeRegistry
 query = QueryType()
 
 payload = {"success": False, "errors": None}
@@ -34,3 +35,11 @@ def resolve_getSerials(obj, info, **kwargs):
 @query.field("getCameras")
 def resolve_getCameras(obj, info, **kwargs):
     return {"satatus": True,  "data": CameraManager.get()}
+
+
+@query.field("getNodeInfo")
+def resolve_getNodeInfo(obj, info, node_type):
+    """Get a Node by id and return it like a payload"""
+    result = (NodeRegistry.getNodeClassByName(node_type)).get_info()
+    print(result)
+    return {'status': True, 'data': result}

--- a/backend/src/graphql/results.graphql
+++ b/backend/src/graphql/results.graphql
@@ -48,3 +48,9 @@ type AlertResult {
   buttonText: String
   buttonAction: String
 }
+
+type NodeInfoResult {
+  status: Boolean!
+  error:[String]
+  data: NodeInfo
+}

--- a/backend/src/graphql/schema.graphql
+++ b/backend/src/graphql/schema.graphql
@@ -42,6 +42,8 @@ type Mutation {
 type Query {
   getNodeSheet(id: ID!): NodeSheetResult!
 
+  getNodeInfo(node_type: ID!): NodeInfoResult!
+
   getCamera(id: ID!): CameraResult!
   getCameras: CamerasResult!
 

--- a/backend/src/graphql/types.graphql
+++ b/backend/src/graphql/types.graphql
@@ -78,3 +78,10 @@ type DefaultStatus{
   status: Boolean
   error: [String]
 }
+
+type NodeInfo{
+  _id: ID
+  name: String
+  type: String
+  options: JSON
+}

--- a/backend/src/nodes/camera/camera_node.py
+++ b/backend/src/nodes/camera/camera_node.py
@@ -1,3 +1,4 @@
+from src.manager.camera_manager import CameraManager
 from src.nodes.node_manager import NodeManager
 from src.nodes.base_node import BaseNode
 from src.nodes.camera.custom_camera import camera
@@ -37,3 +38,12 @@ class CameraNode(BaseNode):
 
     def reset(self):
         self.stop_event = self.execute()
+
+    @staticmethod
+    def get_info():
+        info  = {}
+        print(CameraManager.get())
+        info["options"] =  {
+            "hardware": CameraManager.get()
+        }
+        return info

--- a/backend/src/nodes/camera/custom_camera.py
+++ b/backend/src/nodes/camera/custom_camera.py
@@ -87,7 +87,7 @@ class camera:
         self.properties = {}
         if self.stream.isOpened():
             (self.grabbed, self.frame) = self.stream.read()
-            CameraManager.add(self)
+        CameraManager.add(self)
 
     def set_property(self, name, value):
         self.stream.set(getattr(cv2, name) if isinstance(name, str) else name, value)
@@ -163,7 +163,7 @@ class camera:
         Returns a dictionary representation of the camera.
         """
         return {
-            "_id": self._id,
+            "_id": str(self._id),
             "src": self.src,
             "name": self.name,
             "properties": self.properties,

--- a/backend/src/nodes/compare/comparedimensionaldata_node.py
+++ b/backend/src/nodes/compare/comparedimensionaldata_node.py
@@ -4,7 +4,7 @@ from src.nodes.compare.compare_obj import data_comparatives
 
 NODE_TYPE = "COMPARATIVE_DIMENSIONAL_DATA"
 
-class CompareNode(BaseNode):
+class ComparedimensionaldataNode(BaseNode):
     """
     Node to execute logical operations between values.
     """

--- a/backend/src/nodes/node_registry.py
+++ b/backend/src/nodes/node_registry.py
@@ -51,5 +51,5 @@ for _dir in list(
 for mod in package_nodes:
     mod["package_name"] = importlib.import_module(mod["package_name"], __package__)
     nodeRegistry.append(
-        RegEntry(mod["class_name"][:-4].lower(), getattr(mod["package_name"], mod["class_name"]))
+        RegEntry(getattr(mod["package_name"], 'NODE_TYPE'), getattr(mod["package_name"], mod["class_name"]))
     )


### PR DESCRIPTION
If a node need render a list of options provide by backend (like created cameras, for a frame provider node), define a "get_info()"  function inside custom node class and then return any data for the query getNodeInfo(node_type: NODE_TYPE){ data{options}}.